### PR TITLE
Store access time for scraping calls

### DIFF
--- a/src/controler.py
+++ b/src/controler.py
@@ -43,9 +43,7 @@ def store_data(data):
     session = Session()
 
     for ramp in data.values():
-        capacity = Capacity(tstamp=ramp.pop('tstamp'),
-                            free_capacity=ramp.pop('free_capacity'),
-                            total_capacity=ramp.pop('total_capacity'))
+        capacity = Capacity(**ramp.pop('utilization'))
 
         parking_ramp = session.query(ParkingRamp).get(ramp['identifier'])
 

--- a/src/scraper.py
+++ b/src/scraper.py
@@ -7,6 +7,7 @@ Module is used to extract general information about parking ramps and details
 about their capacity from the official OPG website:
 https://www.parken-osnabrueck.de/
 """
+import datetime
 import html
 import json
 import logging
@@ -65,8 +66,9 @@ def get_general_info():
 
         logger.info((f'{details["available"]} von {details["capacity"]} frei.'))
 
-        ramp_data['free_capacity'] = details['available']
-        ramp_data['total_capacity'] = details['capacity']
+        ramp_data['utilization'] = {'free_capacity': details['available'],
+                                    'total_capacity': details['capacity'],
+                                    'access_time': datetime.datetime.now()}
 
         del ramp_data['gmapsMarker']
 

--- a/src/scraper.py
+++ b/src/scraper.py
@@ -31,8 +31,8 @@ def raise_for_robots_txt(url, agent_name=AGENT_NAME):
     parser.read()
 
     if not parser.can_fetch(agent_name, url):
-        raise PermissionError(f'The robots.txt permitts the crawling of the '
-                              'site {url}')
+        raise PermissionError('The robots.txt permitts the crawling of the '
+                              'site {}'.format(url))
 
 
 def get_details(url=None):
@@ -60,11 +60,11 @@ def get_general_info():
     utilization = get_details(r'https://www.parken-osnabrueck.de/index.php?type=427590&tx_tiopgparkhaeuserosnabrueck_parkingosnabruek[controller]=Parking&tx_tiopgparkhaeuserosnabrueck_parkingosnabruek[action]=ajaxCallGetUtilizationData&_=1556046149040')
 
     for identifier, ramp_data in parking_ramps.items():
-        logger.info(f'Parking Ramp Name: {ramp_data["name"]}')
+        logger.info('Parking Ramp Name: {}'.format(ramp_data['name']))
 
         details = utilization['ramp-' + identifier]
 
-        logger.info((f'{details["available"]} von {details["capacity"]} frei.'))
+        logger.info(('{available} von {capacity} frei.').format(**details))
 
         ramp_data['utilization'] = {'free_capacity': details['available'],
                                     'total_capacity': details['capacity'],

--- a/src/storage.py
+++ b/src/storage.py
@@ -25,13 +25,14 @@ class ParkingRamp(Base):
     latitude = Column(String)
     longitude = Column(String)
     address = Column(String)
+    tstamp = Column(Integer)
 
 
 class Capacity(Base):
     __tablename__ = 'capacities'
 
     identifier = Column(Integer, primary_key=True)
-    tstamp = Column(Integer)
+    access_time = Column(Integer)
     free_capacity = Column(Integer)
     total_capacity = Column(Integer)
     parking_ramp_identifier = Column(Integer,


### PR DESCRIPTION
These changes address Issue #8.

The database structure changed, therefore every database created so far becomes invalid. The data is useless as no correct access time was written!

I also removed usage of f-strings to be runnable on devices not having easy access to Python >=3.6